### PR TITLE
Feat/consult detail of bilemo product

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "doctrine/orm": "^2.10",
     "jms/serializer-bundle": "^4.0",
     "lexik/jwt-authentication-bundle": "^2.14",
+    "sensio/framework-extra-bundle": "^6.2",
     "symfony/apache-pack": "^1.0",
     "symfony/cache": "5.3.*",
     "symfony/console": "5.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26aafd51a470f6283afff446918fc18d",
+    "content-hash": "a6fddaa638a551c0589190fcc3d9d3dd",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -2397,6 +2397,84 @@
                 "source": "https://github.com/php-fig/log/tree/2.0.0"
             },
             "time": "2021-07-14T16:41:46+00:00"
+        },
+        {
+            "name": "sensio/framework-extra-bundle",
+            "version": "v6.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
+                "reference": "7fd1d54c1b27f094a68ae15a99b7fc815857255f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/7fd1d54c1b27f094a68ae15a99b7fc815857255f",
+                "reference": "7fd1d54c1b27f094a68ae15a99b7fc815857255f",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0",
+                "php": ">=7.2.5",
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/framework-bundle": "^4.4|^5.0|^6.0",
+                "symfony/http-kernel": "^4.4|^5.0|^6.0"
+            },
+            "conflict": {
+                "doctrine/doctrine-cache-bundle": "<1.3.1",
+                "doctrine/persistence": "<1.3"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.10|^3.0",
+                "doctrine/doctrine-bundle": "^1.11|^2.0",
+                "doctrine/orm": "^2.5",
+                "symfony/browser-kit": "^4.4|^5.0|^6.0",
+                "symfony/doctrine-bridge": "^4.4|^5.0|^6.0",
+                "symfony/dom-crawler": "^4.4|^5.0|^6.0",
+                "symfony/expression-language": "^4.4|^5.0|^6.0",
+                "symfony/finder": "^4.4|^5.0|^6.0",
+                "symfony/monolog-bridge": "^4.0|^5.0|^6.0",
+                "symfony/monolog-bundle": "^3.2",
+                "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0",
+                "symfony/security-bundle": "^4.4|^5.0|^6.0",
+                "symfony/twig-bundle": "^4.4|^5.0|^6.0",
+                "symfony/yaml": "^4.4|^5.0|^6.0",
+                "twig/twig": "^1.34|^2.4|^3.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sensio\\Bundle\\FrameworkExtraBundle\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "/tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "This bundle provides a way to configure your controllers with annotations",
+            "keywords": [
+                "annotations",
+                "controllers"
+            ],
+            "support": {
+                "issues": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues",
+                "source": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/tree/v6.2.1"
+            },
+            "time": "2021-10-20T09:43:03+00:00"
         },
         {
             "name": "symfony/apache-pack",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -9,4 +9,5 @@ return [
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
     JMS\SerializerBundle\JMSSerializerBundle::class => ['all' => true],
     Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle::class => ['all' => true],
+    Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class => ['all' => true],
 ];

--- a/config/packages/sensio_framework_extra.yaml
+++ b/config/packages/sensio_framework_extra.yaml
@@ -1,0 +1,3 @@
+sensio_framework_extra:
+    router:
+        annotations: false

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,6 +1,15 @@
 api_login_check:
   path: /api/login
+  methods: POST
 
 api_get_products:
   path: /api/products
   controller: App\Controller\ProductController::index
+  methods: GET
+
+api_get_product:
+  path: /api/product/{id}
+  controller: App\Controller\ProductController::show
+  methods: GET
+  requirements:
+    id: '\d+'

--- a/src/Controller/ProductController.php
+++ b/src/Controller/ProductController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Entity\Product;
 use App\Repository\ProductRepository;
 use App\Service\PaginationService;
 use JMS\Serializer\SerializerInterface;
@@ -15,7 +16,7 @@ class ProductController extends AbstractController
 {
     public function __construct(
         private SerializerInterface $serializer,
-        private PaginationService $pagination,
+        private PaginationService   $pagination,
     ) {
     }
 
@@ -33,6 +34,16 @@ class ProductController extends AbstractController
         return new JsonResponse(
             $this->serializer->serialize($pagination, 'json'),
             Response::HTTP_PARTIAL_CONTENT,
+            ['Content-Type' => 'application/hal+json'],
+            true
+        );
+    }
+
+    public function show(Product $product, Request $request): JsonResponse
+    {
+        return new JsonResponse(
+            $this->serializer->serialize($product, 'json'),
+            Response::HTTP_OK,
             ['Content-Type' => 'application/hal+json'],
             true
         );

--- a/src/Entity/Product.php
+++ b/src/Entity/Product.php
@@ -4,7 +4,34 @@ namespace App\Entity;
 
 use App\Repository\ProductRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Hateoas\Configuration\Annotation as Hateoas;
 
+/**
+ * @Hateoas\Relation(
+ *      "self",
+ *      href = @Hateoas\Route(
+ *          "api_get_product",
+ *          absolute=true,
+ *          parameters = { "id" = "expr(object.getId())" }
+ *      ),
+ * )
+ * @Hateoas\Relation(
+ *      "next",
+ *      href = @Hateoas\Route(
+ *          "api_get_product",
+ *          absolute=true,
+ *          parameters = { "id" = "expr(object.getId() + 1)" }
+ *      ),
+ * )
+ * @Hateoas\Relation(
+ *      "last",
+ *      href = @Hateoas\Route(
+ *          "api_get_product",
+ *          absolute=true,
+ *          parameters = { "id" = "expr(object.getId() + 1)" }
+ *      ),
+ * )
+ */
 #[ORM\Entity(repositoryClass: ProductRepository::class)]
 class Product
 {

--- a/symfony.lock
+++ b/symfony.lock
@@ -266,6 +266,18 @@
     "sebastian/version": {
         "version": "3.0.2"
     },
+    "sensio/framework-extra-bundle": {
+        "version": "6.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "5.2",
+            "ref": "fb7e19da7f013d0d422fa9bce16f5c510e27609b"
+        },
+        "files": [
+            "config/packages/sensio_framework_extra.yaml"
+        ]
+    },
     "symfony/apache-pack": {
         "version": "1.0",
         "recipe": {


### PR DESCRIPTION
An authenticated client can now consult the detail of a Bilemo's product on the route /api/product/{id}.
If the client isn't authenticated the api return a 401, else, it return a product with it's json-ld data. If the id doesn't exist, it return a 404 not found